### PR TITLE
Fix Flaky Devcontainer + Python Configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,26 +6,27 @@
   },
   "customizations": {
     "vscode": {
-      "settings": {
-        "python.testing.unittestEnabled": true,
-        "python.testing.unittestArgs": ["-v", "-s", ".", "-p", "test_*.py"]
-      },
       "extensions": [
+        "eamodio.gitlens",
+        "ms-azuretools.vscode-docker",
         "ms-python.python",
         "ms-python.vscode-pylance",
         "ms-vscode-remote.remote-ssh",
         "ms-vscode-remote.remote-ssh-edit"
-      ]
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "terminal.integrated.profiles.linux": {
+          "bash": {
+            "path": "/usr/bin/bash"
+          }
+        }
+      }
     }
   },
   "containerUser": "developer",
   "remoteUser": "developer",
-  "runArgs": [
-    "--userns=keep-id:uid=1000,gid=1000"
-  ],
-  "containerEnv": {
-    "SHELL": "/bin/bash"
-  },
   "updateRemoteUserUID": true,
   "postCreateCommand": ".devcontainer/post_create_command.sh"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,10 @@
 {
+  "files.autoSave": "onFocusChange",
+  "files.exclude": {
+    "**/__pycache__": true
+  },
   "git.autorefresh": true,
+  "python.testing.pytestEnabled": false,
   "python.testing.unittestEnabled": true,
   "python.testing.unittestArgs": ["-v", "-s", ".", "-p", "test_*.py"]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,10 @@
 [tool.poetry]
-name = "bridge-trainer"
-version = "0.1.0"
-description = ""
 authors = ["Caleb Meyer"]
+name = "bridge-trainer"
+description = ""
+package-mode = false
 readme = "README.md"
+version = "0.1.0"
 
 [tool.poetry.dependencies]
 python = "^3.12"


### PR DESCRIPTION
I was experiencing some issues running unit tests that utilized third party python libraries through the Testing extension in VS Code. It seems there was some desynchronization between the devcontainer's python interpreter where Poetry had installed the libraries, and the python interpreter being used by VS Code to run the unit tests.

- Explicitly set path to python interpreter within devcontainer
- Set `bash` as default shell
